### PR TITLE
Add pre-generated alerting rules

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,11 +38,14 @@ steps:
 
   - name: install-borg
     image: python:3.9.1
+    environment:
+      GITHUB_TOKEN:
+        from_secret: GITHUB_TOKEN
     commands:
       - curl https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 -o ./fetch -L
       - chmod +x ./fetch
-      - ./fetch --repo https://github.com/borgbackup/borg --release-asset="borg-linux64" --tag=1.1.16 /tmp
-      - ./fetch --repo https://github.com/danihodovic/borgmatic-binary --release-asset='borgmatic' --tag 1.5.13 /tmp
+      - ./fetch --github-oauth-token=$GITHUB_TOKEN --repo https://github.com/borgbackup/borg --release-asset="borg-linux64" --tag=1.1.16 /tmp
+      - ./fetch --github-oauth-token=$GITHUB_TOKEN --repo https://github.com/danihodovic/borgmatic-binary --release-asset='borgmatic' --tag 1.5.13 /tmp
       - mv /tmp/borg-linux64 borg
       - mv /tmp/borgmatic borgmatic
       - chmod +x borg borgmatic

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ chmod +x borg-exporter
 sudo mv ./borg-exporter /usr/local/bin/
 sudo borg-exporter enable-systemd
 ```
+
+## Alerting rules
+
+Alerting rules can be found [here](./borg-mixin/prometheus-alerts.yaml). By
+default Prometheus sends an alert if a backup hasn't been issued in 24h5m.
+
+The Grafana dashboard is [here](./borg-mixin/dashboards_out/dashboard.json) and
+can be imported directly into the Grafana UI.

--- a/README.md
+++ b/README.md
@@ -29,5 +29,8 @@ sudo borg-exporter enable-systemd
 Alerting rules can be found [here](./borg-mixin/prometheus-alerts.yaml). By
 default Prometheus sends an alert if a backup hasn't been issued in 24h5m.
 
-The Grafana dashboard is [here](./borg-mixin/dashboards_out/dashboard.json) and
-can be imported directly into the Grafana UI.
+## Grafana Dashboard
+
+You can find the generated Grafana dashboard [here](./borg-mixin/dashboards_out/dashboard.json) and it can be imported directly into the Grafana UI.
+
+It's also available in [Grafana's Dashboard Library](https://grafana.com/grafana/dashboards/14489).

--- a/borg-mixin/.gitignore
+++ b/borg-mixin/.gitignore
@@ -1,4 +1,2 @@
-*.yaml
-dashboards_out
 vendor
 jsonnetfile.lock.json

--- a/borg-mixin/README.md
+++ b/borg-mixin/README.md
@@ -2,7 +2,9 @@
 
 A set of Grafana dashboards and Prometheus alerts for Borg.
 
-## How to use
+You can find generated rules [here](./prometheus-alerts.yaml).
+
+## How generate the alert files
 
 This mixin is designed to be vendored into the repo with your infrastructure config.
 To do this, use [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler):

--- a/borg-mixin/README.md
+++ b/borg-mixin/README.md
@@ -4,6 +4,10 @@ A set of Grafana dashboards and Prometheus alerts for Borg.
 
 You can find generated rules [here](./prometheus-alerts.yaml).
 
+You can find the generated Grafana dashboard [here](./dashboards_out/dashboard.json) and it can be imported directly into the Grafana UI.
+
+It's also available in [Grafana's Dashboard Library](https://grafana.com/grafana/dashboards/14489).
+
 ## How generate the alert files
 
 This mixin is designed to be vendored into the repo with your infrastructure config.

--- a/borg-mixin/dashboards_out/dashboard.json
+++ b/borg-mixin/dashboards_out/dashboard.json
@@ -1,0 +1,178 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Borg",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "columns": [ ],
+         "datasource": "$datasource",
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 1
+         },
+         "id": 3,
+         "links": [ ],
+         "sort": {
+            "col": 2,
+            "desc": false
+         },
+         "span": "6",
+         "styles": [
+            {
+               "alias": "Time",
+               "dateFormat": "YYYY-MM-DD HH:mm:ss",
+               "pattern": "Time",
+               "type": "hidden"
+            },
+            {
+               "alias": "Repository",
+               "pattern": "repo"
+            },
+            {
+               "alias": "Total Backups",
+               "pattern": "Value #A",
+               "type": "number",
+               "unit": "short"
+            },
+            {
+               "alias": "Last Backup",
+               "decimals": "0",
+               "pattern": "Value #B",
+               "type": "number",
+               "unit": "dateTimeAsSystem"
+            },
+            {
+               "alias": "Time Since last Backup",
+               "colorMode": "cell",
+               "colors": [
+                  "rgba(50, 172, 45, 0.97)",
+                  "rgba(237, 129, 40, 0.89)",
+                  "rgba(245, 54, 54, 0.9)"
+               ],
+               "decimals": "1",
+               "pattern": "Value #C",
+               "thresholds": [
+                  "65025",
+                  "86700"
+               ],
+               "type": "number",
+               "unit": "dtdurations"
+            }
+         ],
+         "targets": [
+            {
+               "expr": "sum by (repo, instance) (borg_backups_total{job=\"borg-db\"})\n",
+               "format": "table",
+               "instant": true,
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            },
+            {
+               "expr": "sum by (repo, instance) (borg_last_backup_timestamp{job=\"borg-db\"}) * 1000\n",
+               "format": "table",
+               "instant": true,
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "B"
+            },
+            {
+               "expr": "time() - sum by (repo, instance) (borg_last_backup_timestamp{job=\"borg-db\"})\n",
+               "format": "table",
+               "instant": true,
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "C"
+            }
+         ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Backups",
+         "type": "table"
+      }
+   ],
+   "refresh": "",
+   "rows": [ ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [ ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "Prometheus",
+               "value": "Prometheus"
+            },
+            "hide": 0,
+            "label": null,
+            "name": "datasource",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         }
+      ]
+   },
+   "time": {
+      "from": "now-12h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Borg Backups",
+   "version": 0
+}

--- a/borg-mixin/prometheus-alerts.yaml
+++ b/borg-mixin/prometheus-alerts.yaml
@@ -1,0 +1,11 @@
+"groups":
+- "name": "borg"
+  "rules":
+  - "alert": "BorgMissingBackup"
+    "annotations":
+      "description": "The instance {{ $labels.instance }} has not created a backup of the repo {{ $labels.repo }} in the last {{ $value }} seconds."
+      "summary": "Borg missing backup."
+    "expr": "time() - sum by (repo, instance) (borg_last_backup_timestamp{job=\"borg-db\"}) > 86700"
+    "for": "1m"
+    "labels":
+      "severity": "warning"


### PR DESCRIPTION
To generate the alerting rules files you need to install:

- jsonnet
- jb
- promtool

This is annoying unless you're a seasoned Prometheus developer, so let's
add pre-generated files for the rest of us.
