### PR TITLE
Change to updated Borg by changing command.

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -30,8 +30,8 @@ def create_metrics(registry):
 
 def collect(borgmatic_configs, registry):
     borgmatic_configs = " ".join(borgmatic_configs)
-    list_infos = run_borgmatic_cmd(f"borgmatic --list -c {borgmatic_configs} --json")
-    repo_infos = run_borgmatic_cmd(f"borgmatic --info -c {borgmatic_configs} --json")
+    list_infos = run_borgmatic_cmd(f"borgmatic list -c {borgmatic_configs} --json")
+    repo_infos = run_borgmatic_cmd(f"borgmatic info -c {borgmatic_configs} --json")
 
     for i in range(len(list_infos)):
         archives = list_infos[i]["archives"]


### PR DESCRIPTION
Borgmatic recently changed there command to remove the -- and instead it is now just borgmatic info and list. I have changed this here. There isn't really any reason for anyone to be using an older version of borgmatic on new installations. So i see no harm in making this a permanent change. 