### PR TITLE
fix: default type for the config file option

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -17,7 +17,7 @@ def config_opt(func):
     return click.option(
         "-c",
         "--config",
-        default="/etc/borgmatic/config.yaml",
+        default=["/etc/borgmatic/config.yaml"],
         help="The path to the borgmatic config file",
         multiple=True,
         type=click.Path(


### PR DESCRIPTION
Otherwise this happens:

```
core.py 2151 __init__
raise ValueError(

ValueError:
'default' must be a list when 'multiple' is true.
```

https://github.com/danihodovic/borg-exporter/issues/60